### PR TITLE
Multiple objects validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,44 @@ Array
 )
 */
 ```
+And you can also validate multiple identical objects into array using asterisk sign in this way:
 
+```php
+use Respect\Validation\Validator as v;
+
+$app = new \Slim\App();
+
+//Create the validators
+$nameValidator = v::alnum()->length(1, 100);
+$ageValidator = v::numeric()->between(0, 120);
+$validators = array(
+  'people' => array(
+    '*' => array(
+      'name' => $nameValidator,
+      'age' => $ageValidator,
+    )
+  ),
+);
+```
+
+If you'll have an error in some of objects, the result would be like this where **2** is the index of the object into *people* array:
+
+```php
+//In your route
+$errors = $req->getAttribute('errors');
+
+print_r($errors);
+/*
+Array
+(
+    [people.2.age] => Array
+        (
+            [0] => "180 must be less than or equal to 120"
+        )
+
+)
+*/
+```
 
 ### XML requests
 

--- a/src/Validation.php
+++ b/src/Validation.php
@@ -124,7 +124,17 @@ class Validation
             $actualKeys[] = $key;
             $param = $this->getNestedParam($params, $actualKeys);
             if (is_array($validator)) {
-                $this->validate($params, $validator, $actualKeys);
+                if ($key === "*") {
+                    $arrayKeys = array_keys($params[$actualKeys[0]]);
+                    $innerActualKeys = array_splice($actualKeys, 0, -1);
+                    foreach ($arrayKeys as $arrayKey) {
+                        $innerActualKeys[] = $arrayKey;
+                        $this->validate($params, $validator, $innerActualKeys);
+                        array_pop($innerActualKeys);
+                    }
+                } else {
+                    $this->validate($params, $validator, $actualKeys);
+                }
             } else {
                 try {
                     $validator->assert($param);

--- a/tests/ValidationTest.php
+++ b/tests/ValidationTest.php
@@ -417,6 +417,34 @@ class ValidationTest extends \PHPUnit_Framework_TestCase
               ),
             ),
           ),
+          //Multiple nested JSON validation with errors
+          array(
+            array(
+              'messages' => array(
+                '*' => array(
+                  'title' => v::stringType()->length(6, null)->setName("messageTitle")
+                )
+              ),
+            ),
+            null,
+            true,
+            array(
+              'messages.0.title' => array(
+                'messageTitle must have a length greater than 6',
+              ),
+            ),
+            'JSON',
+            array(
+              'messages' => array(
+                array(
+                  'title' => 'Title'
+                ),
+                array(
+                  'title' => 'Long title'
+                ),
+              ),
+            ),
+          ),
 
           //XML validation without errors
           array(


### PR DESCRIPTION
Added possibility to validate multiple identical objects in array using asterisk sidn as a mask.
For object like this:
```json
{
  "people": [{
    "name": "Mark",
    "age": 29
  }, {
    "name": "Olga",
    "age": 31
  }]
}
```
...or this:
```json
{
  "people": {
    "first": {
      "name": "Mark",
      "age": 29
    }, 
    "second": {
      "name": "Olga",
      "age": 31
    }
  }
}
```

validation rules would be:
```php
[
  'people' => [
    '*' => [
      'name' => v::alnum(),
      'age' => v::numeric()
    ]
  ]
]
```
